### PR TITLE
Add nagging scroll popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,9 @@
       <h2>id__a</h2>
    </div>
    <div class="down-indicator">
-      <!-- <i class='bx bx-chevron-down bx-lg'></i>
-      <i class='bx bx-chevron-down bx-lg'></i>
-      <i class='bx bx-chevron-down bx-lg'></i> -->
+      <p>Scroll for more</p>
+      <i class='bx bx-chevron-down bx-md'></i>
+      <i class='bx bx-chevron-down bx-md'></i>
    </div>
 
    <main>

--- a/index.html
+++ b/index.html
@@ -39,8 +39,10 @@
    </div>
    <div class="down-indicator">
       <p>Scroll for more</p>
-      <i class='bx bx-chevron-down bx-md'></i>
-      <i class='bx bx-chevron-down bx-md'></i>
+      <div class="down-arrow">
+         <i class='bx bx-chevron-down bx-md'></i>
+         <i class='bx bx-chevron-down bx-md'></i>
+      </div>
    </div>
 
    <main>

--- a/script.js
+++ b/script.js
@@ -27,15 +27,69 @@ document.addEventListener('DOMContentLoaded', () => {
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         setTheme(prefersDark);
     }
+    
+    // Animation sequence for name and down indicator
+    const nameElement = document.querySelector(".name h2");
+    const downIndicator = document.querySelector(".down-indicator");
+    
+    if (nameElement && downIndicator) {
+        // Hide down indicator initially
+        downIndicator.style.opacity = "0";
+        
+        // Calculate total delay (animation time + 1 second)
+        const nameAnimationDuration = 500; // 0.5s from CSS
+        const additionalDelay = 1000; // 1 second delay
+        
+        // Show down indicator after name animation + delay
+        setTimeout(() => {
+            if (window.scrollY === 0) { // Only show if still at top
+                downIndicator.style.opacity = "1";
+            }
+        }, nameAnimationDuration + additionalDelay);
+    }
 });
 
-
 // Function runs on scrolling and on window resize
-window.onscroll = function() {scrollIndicator()};
-window.onresize = function() {scrollIndicator()};
+window.onscroll = function() {
+    scrollIndicator();
+    updateDownIndicator();
+};
+window.onresize = function() {
+    scrollIndicator();
+    updateDownIndicator();
+};
 
 // Also check on initial load
-document.addEventListener('DOMContentLoaded', scrollIndicator);
+document.addEventListener('DOMContentLoaded', function() {
+    scrollIndicator();
+    // Remove updateDownIndicator() from here as we're handling it separately
+});
+
+// Add a variable to store the timeout ID
+let downIndicatorTimeout;
+
+function updateDownIndicator() {
+    const downIndicator = document.querySelector(".down-indicator");
+    
+    if (!downIndicator) return;
+    
+    // Clear any existing timeout
+    if (downIndicatorTimeout) {
+        clearTimeout(downIndicatorTimeout);
+    }
+    
+    if (window.scrollY > 0) {
+        // Hide the indicator when not at the top
+        downIndicator.style.opacity = "0";
+    } else {
+        // When at the top, show the indicator after a delay
+        downIndicatorTimeout = setTimeout(() => {
+            if (window.scrollY === 0) { // Double-check we're still at the top
+                downIndicator.style.opacity = "1";
+            }
+        }, 1000); // 1-second delay
+    }
+}
 
 // Function to show scrolling indicator
 function scrollIndicator() {

--- a/style.css
+++ b/style.css
@@ -212,6 +212,45 @@ main {
 }
 
 /* ===========================
+   Down Indicator Styles
+   =========================== */
+.down-indicator {
+   position: absolute;
+   bottom: 30px;
+   left: 50%;
+   transform: translateX(-50%);
+   display: flex;
+   flex-direction: column;
+   justify-content: center;
+   align-items: center;
+   color: var(--text-colour);
+   opacity: 0;
+   transition: opacity 0.3s ease;
+   animation: bounce 2s infinite;
+}
+
+.down-indicator p {
+   margin-bottom: 5px;
+   font-size: 14px;
+}
+
+.down-indicator i {
+   line-height: 0.5;
+}
+
+@keyframes bounce {
+   0%, 20%, 50%, 80%, 100% {
+      transform: translateX(-50%) translateY(0);
+   }
+   40% {
+      transform: translateX(-50%) translateY(-10px);
+   }
+   60% {
+      transform: translateX(-50%) translateY(-5px);
+   }
+}
+
+/* ===========================
    About Me, Experience and Projects Styles
    =========================== */
 

--- a/style.css
+++ b/style.css
@@ -234,8 +234,17 @@ main {
    font-size: 14px;
 }
 
+.down-arrow {
+   background-color: var(--base-variant-1);
+   border-radius: 100px;
+   display: flex;
+   flex-direction: column;
+   align-items: center;
+   padding: 9px 2px;
+}
+
 .down-indicator i {
-   line-height: 0.5;
+   line-height: 0.3;
 }
 
 @keyframes bounce {


### PR DESCRIPTION
Add nagging scroll popup for more interactivity. The popup initially shows up 1.5secs after page load to allow the reader to first read id__a, and if scrolled down and then back up, will appear 1sec later.
- `index.html`:

   ```diff
   -      <!-- <i class='bx bx-chevron-down bx-lg'></i>
   -      <i class='bx bx-chevron-down bx-lg'></i>
   -      <i class='bx bx-chevron-down bx-lg'></i> -->
   +      <p>Scroll for more</p>
   +      <div class="down-arrow">
   +         <i class='bx bx-chevron-down bx-md'></i>
   +         <i class='bx bx-chevron-down bx-md'></i>
   +      </div>
   ```
Here's a preview of the finished result:
![ezgif-12b4d480b0254f](https://github.com/user-attachments/assets/b03e0cde-f38d-413e-b8b7-3dfc7010e32f)
